### PR TITLE
Fix CORS origin error when an invalid TOTP code is submitted

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
     "express-session": "^1.17.3",
+    "helmet": "^6.0.1",
     "multer": "^1.4.5-lts.1",
     "nest": "^0.1.6",
     "otplib": "^12.0.1",

--- a/backend/src/chat/socketAdapter.ts
+++ b/backend/src/chat/socketAdapter.ts
@@ -2,19 +2,7 @@ import { IoAdapter } from '@nestjs/platform-socket.io';
 import { ServerOptions } from 'socket.io';
 
 export class SocketAdapter extends IoAdapter {
-  createIOServer(
-    port: number,
-    options?: ServerOptions & {
-      namespace?: string;
-      server?: any;
-    },
-  ) {
-    const server = super.createIOServer(port, {
-      ...options,
-      cors: {
-        origin: true,
-      },
-    });
-    return server;
+  createIOServer(port: number, options?: ServerOptions) {
+    return super.createIOServer(port, { ...options, cors: true });
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,6 +6,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { PrismaSessionStore } from '@quixo3/prisma-session-store';
 import * as cookieParser from 'cookie-parser';
 import * as ExpressSession from 'express-session';
+import helmet from 'helmet';
 import * as passport from 'passport';
 import { AppModule } from 'src/app.module';
 import { Config } from 'src/config.interface';
@@ -16,16 +17,18 @@ import { SocketAdapter } from './chat/socketAdapter';
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
-  // Define websocket settings for the chat page
-  app.useWebSocketAdapter(new SocketAdapter(app));
-
   const config = app.get(ConfigService<Config>);
   const prisma = app.get(PrismaService);
+
+  // Define websocket settings for the chat page
+  app.useWebSocketAdapter(new SocketAdapter(app));
 
   await prisma.enableShutdownHooks(app);
 
   setupSwagger(app);
   setupSession(app, config, prisma);
+
+  app.use(helmet());
 
   app.useGlobalPipes(
     new ValidationPipe({
@@ -33,9 +36,11 @@ async function bootstrap() {
     }),
   );
 
+  const frontendUrl = config.getOrThrow('FRONTEND_URL');
+
   app.enableCors({
-    origin: true,
     credentials: true,
+    origin: frontendUrl,
   });
 
   await app.listen(config.getOrThrow('BACKEND_PORT'));

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -36,11 +36,9 @@ async function bootstrap() {
     }),
   );
 
-  const frontendUrl = config.getOrThrow('FRONTEND_URL');
-
   app.enableCors({
     credentials: true,
-    origin: frontendUrl,
+    origin: config.getOrThrow('FRONTEND_URL'),
   });
 
   await app.listen(config.getOrThrow('BACKEND_PORT'));

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -3675,6 +3675,11 @@ hasha@5.2.2:
     is-stream "^2.0.0"
     type-fest "^0.8.0"
 
+helmet@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-6.0.1.tgz#52ec353638b2e87f14fe079d142b368ac11e79a4"
+  integrity sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==
+
 hexoid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz"


### PR DESCRIPTION
- Add delay to click the validate button so the user does not accidentally submit the same code two times (the button is grayed out during the delay)
- Remove request to `GET /auth/logout` when the code is invalid
- Keep the input modal opened, that way if the user enters an invalid code, they do not have to click the login button again and enter a valid code directly


Fixes #232

Review @jesuisstan, please review this seriously because I may have broken a thing or two