### PR TITLE
Change nickname validation allowed characters

### DIFF
--- a/backend/src/user/dto/setNickname.dto.ts
+++ b/backend/src/user/dto/setNickname.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, Length, Matches } from 'class-validator';
 
-const NICKNAME_VALIDATION_REGEX = /^[A-zA-Z0-9_-]+$/;
+const NICKNAME_VALIDATION_REGEX = /^[A-zA-Z0-9_-]*$/;
 const MIN_LENGTH = 3 as const;
 const MAX_LENGTH = 10 as const;
 

--- a/backend/src/user/dto/setNickname.dto.ts
+++ b/backend/src/user/dto/setNickname.dto.ts
@@ -1,16 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, Length, Matches } from 'class-validator';
+import { IsString, Length, Matches } from 'class-validator';
 
-const NICKNAME_VALIDATION_REGEX = /^[^\[\]<>^$%.\|/?*+() ]+$/;
+const NICKNAME_VALIDATION_REGEX = /^[A-zA-Z0-9_-]+$/;
+const MIN_LENGTH = 3 as const;
+const MAX_LENGTH = 10 as const;
 
 export class SetNicknameDTO {
-  @IsNotEmpty()
-  @Length(3, 10)
+  @IsString()
+  @Length(MIN_LENGTH, MAX_LENGTH)
   @Matches(NICKNAME_VALIDATION_REGEX, { message: 'illegal character' })
   @ApiProperty({
     default: '',
-    minLength: 3,
-    maxLength: 10,
+    minLength: MIN_LENGTH,
+    maxLength: MAX_LENGTH,
     pattern: NICKNAME_VALIDATION_REGEX.toString(),
   })
   nickname: string;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,6 +1,6 @@
 import {
-  BadRequestException,
   Body,
+  ConflictException,
   Controller,
   Get,
   Logger,
@@ -11,7 +11,12 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiBadRequestResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { User } from '@prisma/client';
 import { IsAuthenticatedGuard } from 'src/auth/auth.guard';
 import { SessionUser } from 'src/decorator/session-user.decorator';
@@ -54,7 +59,10 @@ export class UserController {
   @UsePipes(ValidationPipe)
   @ApiBadRequestResponse({
     description:
-      'The username is already taken, or the payload is not formatted well',
+      'The payload is not formatted well or the nickname does not match SetNicknameDTO conditions',
+  })
+  @ApiConflictResponse({
+    description: 'The nickname is already taken',
   })
   async setNickname(
     @SessionUser() user: User,
@@ -64,7 +72,7 @@ export class UserController {
     const foundUser = await this.users.findUserByNickname(nickname);
 
     if (foundUser !== null)
-      throw new BadRequestException('This nickname is already used');
+      throw new ConflictException('This nickname is already used');
     return await this.users.setUserNickname(user, nickname);
   }
 }

--- a/frontend/src/components/profile/EditNickname.tsx
+++ b/frontend/src/components/profile/EditNickname.tsx
@@ -13,6 +13,7 @@ import Typography from '@mui/material/Typography';
 import errorAlert from '../UI/errorAlert';
 import backendAPI from '../../api/axios-instance';
 import * as MUI from '../UI/MUIstyles';
+import axios from 'axios';
 
 const EditNickname = ({
   open,
@@ -21,7 +22,7 @@ const EditNickname = ({
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
 }) => {
-  const { user, setUser } = useContext(UserContext);
+  const { setUser } = useContext(UserContext);
   const [text, setText] = useState('');
   const [error, setError] = useState('');
   const [load, setLoad] = useState(false);
@@ -29,11 +30,11 @@ const EditNickname = ({
 
   const handleTextInput = (event: any) => {
     const newValue = event.target.value;
-    if (!newValue.match(/[%'<#>\$|/?* +^.(){}"]/)) {
-      setError('');
+    if (newValue.match(/^[A-zA-Z0-9_-]*$/)) {
       setText(newValue);
+      setError('');
     } else {
-      setError(`Forbidden: { } < > # ^ " ' $ % . \\ | / ? * + ( ) space`);
+      setError('Allowed characters are Latin letters, digits, dashes and underscores');
     }
   };
 
@@ -53,8 +54,11 @@ const EditNickname = ({
         setUser(response.data);
       },
       (error) => {
-        console.log(error);
-        error.request.status === 400 ? warningNameUsed() : warningWentWrong();
+        if (axios.isAxiosError(error) && error.response?.status === 409) {
+          warningNameUsed();
+        } else {
+          warningWentWrong();
+        }
       }
     );
   };


### PR DESCRIPTION
New regex is `/^[A-zA-Z0-9_-]*$/`, that way only Latin letters, digits, dashes and underscores are allowed.

Fixes #224

Review @jesuisstan 