### PR TITLE
Fix docker compose backend url for both envs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,8 @@ services:
     networks:
       - private
       - public
+    environment:
+      BACKEND_URL: ${BACKEND_URL:?}
     healthcheck:
       test: curl -fsSL http://localhost:3000/healthcheck
       interval: 10s

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,6 +24,8 @@ services:
       - "3000"
     networks:
       - private
+    environment:
+      BACKEND_URL: ${FRONTEND_URL:?}/api
     healthcheck:
       test: curl -fsSL http://localhost:3000/api/healthcheck
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - .env
     environment:
       FRONTEND_URL: ${FRONTEND_URL:?}
-      BACKEND_URL: ${FRONTEND_URL:?}/api
       SESSION_SECRET: ${SESSION_SECRET:?}
       JWT_SECRET: ${JWT_SECRET:?}
       DATABASE_URL: postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@database:5432/pong?schema=public


### PR DESCRIPTION
BACKEND_URL was always ${FRONTEND_URL}/api, regardless of the environment. Now it is only for production, and ${BACKEND_URL} for development.