### PR TITLE
Limit data returned by findAllChatRooms

### DIFF
--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -173,7 +173,15 @@ export class ChatService {
   }
 
   async findAllChatRooms(): Promise<any[]> {
-    return await this.prisma.chatRoom.findMany({ include: { members: true } });
+    return await this.prisma.chatRoom.findMany(
+      {
+        select: {
+          modes: true,
+          name: true,
+          members: true,
+        },
+      }
+    );
   }
 
   // Return all members from the chatroom


### PR DESCRIPTION
Remove sensible data when fetching all chat rooms (password hash, member list)